### PR TITLE
fix: Added LaunchWithOverwolf to event-enum

### DIFF
--- a/overwolf-manifest-schema.json
+++ b/overwolf-manifest-schema.json
@@ -537,7 +537,7 @@
           "description": "The type name of the event.",
           "type": "string",
           "enum": [
-            "GameLaunch","AllGamesLaunch"
+            "GameLaunch","AllGamesLaunch","LaunchWithOverwolf"
           ]
         },
         "tracked": {


### PR DESCRIPTION
Added the `LaunchWithOverwolf`-event, so that we can validate with the JSON schema if we use this method of launching our applications.