### PR TITLE
Create getWindowMonitor.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ You can upload new gists and browse other gists that uploaded by the Overwolf de
 * **center-window-on-first-load.md**  
   center app window to the middle of the screen, only on the first run.
 * **getInGameResolution**
+* **getWindowMonitor.md**
 * **move-window-to-position**
 * **overwolf-manifest-schema.json**  
   validate your manifest using this schema.

--- a/getWindowMonitor.md
+++ b/getWindowMonitor.md
@@ -1,0 +1,47 @@
+/**
+ * get monitor of the window
+ * @returns {Promise<*>}
+ */
+async function getWindowMonitor(name) {
+    return new Promise(async (resolve, reject) => {
+        try {
+            overwolf.windows.obtainDeclaredWindow(name, (result) => {
+                if(result.status === 'success')
+                {
+                    overwolf.utils.getMonitorsList((monitors) => {
+                        if(monitors.success === true)
+                        {
+                            for(let i = 0; i < monitors.displays.length; i++)
+                            {
+                                let display = monitors.displays[i];
+
+                                let xMin    = display.x;
+                                let xMax    = xMin + display.width;
+
+                                if(result.window.left >= xMin && result.window.left <= xMax)
+                                {
+                                    let yMin    = display.y;
+                                    let yMax    = yMin + display.height;
+
+                                    if(result.window.top >= yMin && result.window.top <= yMax)
+                                    {
+                                        resolve(display);
+                                        return;
+                                    }
+                                }
+                            }
+                        }
+
+                        reject(monitors);
+                    });
+                }
+                else
+                {
+                    reject(result);
+                }
+            });
+        } catch (e) {
+            reject(e);
+        }
+    });
+}

--- a/getWindowMonitor.md
+++ b/getWindowMonitor.md
@@ -1,3 +1,4 @@
+```js
 /**
  * get monitor of the window
  * @returns {Promise<*>}
@@ -45,3 +46,4 @@ async function getWindowMonitor(name) {
         }
     });
 }
+```


### PR DESCRIPTION
Used to find the correct monitor for a window. Specially useful for the center function for example, when display[0] isn't always the main screen.